### PR TITLE
Update and rename README to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Silently is a package that allows you to run an IO action and prevent it from writing to stdout, or any other handle, by using "silence". Or you can capture the output for yourself using "capture".
 
 For example; the program
-
+```haskell
  import System.IO.Silently
 
  main = do
@@ -11,10 +11,11 @@ For example; the program
    (captured, result) <- capture (putStr "wookies!" >> return 123)
    putStr "captured: " >> putStrLn captured
    putStr "returned: " >> putStrLn (show result)
-
+```
 will print
-
+```
  putStrLn: puppies!
  silenced:
  captured: wookies!
  returned: 123
+```


### PR DESCRIPTION
Change README to markdown, so we can use syntax coloring for haskell.